### PR TITLE
Update user registration endpoint to include API prefix in documentation and configuration

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"management-be/cmd/api/server/commands"
 	"net/http"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"management-be/cmd/api/server/commands"
 )
 
 func gracefulShutdown(apiServer *http.Server, done chan bool) {

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -91,7 +91,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/register": {
+        "/api/users/register": {
             "post": {
                 "description": "Register a new user with username, password, email and full name",
                 "consumes": [

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -85,7 +85,7 @@
                 }
             }
         },
-        "/users/register": {
+        "/api/users/register": {
             "post": {
                 "description": "Register a new user with username, password, email and full name",
                 "consumes": [

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -120,7 +120,7 @@ paths:
       summary: Login user
       tags:
       - users
-  /users/register:
+  /api/users/register:
     post:
       consumes:
       - application/json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the user registration endpoint path in API documentation from `/users/register` to `/api/users/register` to ensure consistency with other endpoints.
- **Style**
  - Minor reordering of import statements with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->