### PR TITLE
Reset ID sequences after deleting all existing data in the database

### DIFF
--- a/data/seed/main.go
+++ b/data/seed/main.go
@@ -2,64 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
+
 	"management-be/internal/database"
 	"management-be/internal/repository/ent"
 )
-
-func deleteAllData(ctx context.Context, client *ent.Client) error {
-	log.Println("Deleting all existing data...")
-
-	// Delete in reverse order of dependencies
-	if _, err := client.PlayerStatistic.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.TeamFee.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.MatchPlayer.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.Match.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.Player.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.Team.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.User.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	if _, err := client.Department.Delete().Exec(ctx); err != nil {
-		return err
-	}
-
-	// Reset all sequences to 1
-	if _, err := client.ExecContext(ctx, `
-		ALTER SEQUENCE departments_id_seq RESTART WITH 1;
-		ALTER SEQUENCE users_id_seq RESTART WITH 1;
-		ALTER SEQUENCE teams_id_seq RESTART WITH 1;
-		ALTER SEQUENCE players_id_seq RESTART WITH 1;
-		ALTER SEQUENCE matches_id_seq RESTART WITH 1;
-		ALTER SEQUENCE match_players_id_seq RESTART WITH 1;
-		ALTER SEQUENCE team_fees_id_seq RESTART WITH 1;
-		ALTER SEQUENCE player_statistics_id_seq RESTART WITH 1;
-	`); err != nil {
-		return err
-	}
-
-	log.Println("Successfully deleted all existing data and reset ID sequences")
-	return nil
-}
 
 func main() {
 	log.Println("Starting database seeding...")
@@ -110,4 +59,68 @@ func main() {
 	}
 
 	log.Println("Database seeding completed successfully!")
+}
+
+var tableSequences = []string{
+	"departments",
+	"users",
+	"teams",
+	"players",
+	"matches",
+	"match_players",
+	"team_fees",
+	"player_statistics",
+}
+
+func buildResetSequencesSQL() string {
+	var statements []string
+	for _, table := range tableSequences {
+		statements = append(statements, fmt.Sprintf("ALTER SEQUENCE %s_id_seq RESTART WITH 1", table))
+	}
+	return strings.Join(statements, ";\n") + ";"
+}
+
+func deleteAllData(ctx context.Context, client *ent.Client) error {
+	log.Println("Deleting all existing data...")
+
+	// Delete in reverse order of dependencies
+	if _, err := client.PlayerStatistic.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.TeamFee.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.MatchPlayer.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.Match.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.Player.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.Team.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.User.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	if _, err := client.Department.Delete().Exec(ctx); err != nil {
+		return err
+	}
+
+	// Reset all sequences to 1
+	if _, err := client.ExecContext(ctx, buildResetSequencesSQL()); err != nil {
+		return err
+	}
+
+	log.Println("Successfully deleted all existing data and reset ID sequences")
+	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved data reset process to also restart ID sequences for all main tables after data deletion, ensuring IDs start from 1 each time data is cleared. The confirmation message now reflects both data deletion and sequence reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->